### PR TITLE
Set acceptance required to false

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_lb_listener" "mz_msk_listener" {
 
 # Create VPC endpoint service for the Load Balancer
 resource "aws_vpc_endpoint_service" "mz_msk_lb_endpoint_service" {
-  acceptance_required        = true
+  acceptance_required        = var.mz_acceptance_required
   network_load_balancer_arns = [aws_lb.mz_msk_lb.arn]
   tags = {
     Name = "mz-msk-lb-endpoint-service"

--- a/variables.tf
+++ b/variables.tf
@@ -21,3 +21,10 @@ variable "mz_msk_cluster_port" {
 variable "mz_msk_vpc_id" {
   description = "The VPC ID of the existing MSK cluster"
 }
+
+# Endpoint Service Acceptance Required (true/false)
+variable "mz_acceptance_required" {
+  description = "Endpoint Service Manual Acceptance Required (true/false)"
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
As discussed in this PR [here](https://github.com/MaterializeInc/demos/pull/70), setting the endpoint connection `acceptance_required` to false by default.