### PR TITLE
allows module to be used with for_each

### DIFF
--- a/providers.tf
+++ b/providers.tf
@@ -2,11 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 4.0"
+      version = ">= 4.0, < 6.0"
     }
   }
-}
-
-provider "aws" {
-  region = var.aws_region
 }


### PR DESCRIPTION
Module is considered legacy and will not allow calling Terraform to use `for_each` on the module. Removing the AWS provider section from providers allows this to work.